### PR TITLE
Create 'blank issue' template

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank-issue.md
+++ b/.github/ISSUE_TEMPLATE/blank-issue.md
@@ -1,0 +1,10 @@
+---
+name: Blank issue
+about: A blank slate. No labels, no pre-filled content. Just your own imagination.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+


### PR DESCRIPTION
The button for a blank issue is really small at the bottom. I think it's so that people are more likely to try to pick from custom templates, but I'm not convinced this will be a problem. If everyone chooses this one inappropriately, we may remove it.